### PR TITLE
Remove default validator

### DIFF
--- a/contracts/TXValidator.sol
+++ b/contracts/TXValidator.sol
@@ -21,7 +21,6 @@ contract TXValidator is Ownable, ITXValidator {
     mapping(uint => mapping(address => bool)) private _validatorsByGroupId;
     mapping(address => bytes32) private _validatorsNames;
 
-    address public defaultValidator;
     uint public defaultValidFor = 3e4;
     mapping(uint => uint) public validForByGroupId;
 
@@ -30,18 +29,6 @@ contract TXValidator is Ownable, ITXValidator {
     returns (bool)
     {
         return _validatorsByGroupId[groupId_][validator_];
-    }
-
-    constructor(
-        address defaultValidator_
-    ) {
-        defaultValidator = defaultValidator_;
-    }
-
-    function updateDefaultValidator(address newDefaultValidator_) external override
-    onlyOwner
-    {
-        defaultValidator = newDefaultValidator_;
     }
 
     function _addValidator(uint groupId_, bytes32 validatorName_, address validator_) internal
@@ -136,8 +123,7 @@ contract TXValidator is Ownable, ITXValidator {
     returns (address)
     {
         address validator = ECDSA.recover(hash_, signature_);
-//        console.log("validator %s", validator);
-        if (validator == defaultValidator || _validatorsByGroupId[groupId_][validator]) {
+        if (_validatorsByGroupId[groupId_][validator]) {
             return validator;
         } else {
             return address(0);

--- a/contracts/interfaces/ITXValidator.sol
+++ b/contracts/interfaces/ITXValidator.sol
@@ -12,8 +12,6 @@ interface ITXValidator {
     event ValidatorAdded(uint groupId, address validator);
     event ValidatorRemoved(uint groupId, address validator);
 
-    function updateDefaultValidator(address newDefaultValidator_) external;
-
     function isValidatorForGroup(uint groupId_, address validator_) external view returns (bool);
 
     function addValidator(uint groupId_, bytes32 validatorName_, address validator_) external;

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -51,7 +51,7 @@ module.exports = {
     },
     ethereum: {
       url: `https://mainnet.infura.io/v3/${env.infuraApiKey}`,
-      accounts: [env.privateKey]
+      accounts: [env.privateKey0]
     },
     bsc_testnet: {
       url: "https://data-seed-prebsc-1-s1.binance.org:8545",

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -92,14 +92,18 @@ async function deploy(ethers) {
 
     // txValidator
     const TXValidator = await ethers.getContractFactory("TXValidator");
-    const txValidator = await TXValidator.deploy(validator);
+    const txValidator = await TXValidator.deploy();
     await txValidator.deployed();
 
-    await fs.writeFile(
-        path.join(argumentsDir, 'TXValidator.js'),
-        `module.exports = [
-    '${validator}'
-]`)
+    await txValidator.addValidator(1, utils.stringToBytes32('0xnil'), validator)
+    await txValidator.addValidator(2, utils.stringToBytes32('0xnil'), validator)
+    await txValidator.addValidator(3, utils.stringToBytes32('0xnil'), validator)
+
+//     await fs.writeFile(
+//         path.join(argumentsDir, 'TXValidator.js'),
+//         `module.exports = [
+//     '${validator}'
+// ]`)
 
     // identity manager
     const DeIDManager = await ethers.getContractFactory("DeIDManager");

--- a/shell/verify.sh
+++ b/shell/verify.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # must be run from the root
 
-npx hardhat verify --show-stack-traces --network $1 --constructor-args tmp/arguments/$1/TXValidator.js $2
+npx hardhat verify --show-stack-traces --network $1 $2
 npx hardhat verify --show-stack-traces --network $1 --constructor-args tmp/arguments/$1/DeIDStore.js $3
 npx hardhat verify --show-stack-traces --network $1 --constructor-args tmp/arguments/$1/DeIDManager.js $4
 npx hardhat verify --show-stack-traces --network $1 --constructor-args tmp/arguments/$1/DeIDClaimer.js $5

--- a/test/DeIDManager.test.js
+++ b/test/DeIDManager.test.js
@@ -52,9 +52,11 @@ describe("DeIDManager", async function () {
     claimer = await DeIDClaimer.deploy(store.address);
     await claimer.deployed();
     TXValidator = await ethers.getContractFactory("TXValidator");
-    txValidator = await TXValidator.deploy(validator.address);
+    txValidator = await TXValidator.deploy();
     await txValidator.deployed();
     await txValidator.addValidator(1, utils.stringToBytes32('tweedentityV2'), validator.address)
+    await txValidator.addValidator(2, utils.stringToBytes32('tweedentityV2'), validator.address)
+    await txValidator.addValidator(3, utils.stringToBytes32('tweedentityV2'), validator.address)
     DeIDManager = await ethers.getContractFactory("DeIDManager");
     identity = await DeIDManager.deploy(store.address, claimer.address, txValidator.address);
     await identity.deployed();
@@ -167,7 +169,7 @@ describe("DeIDManager", async function () {
 
       await assertThrowsMessage(
           identity.connect(bob).setIdentity(6, tid, timestamp, signature),
-          'Unsupported app')
+          'Invalid signature')
     })
 
     it('should throw if already set', async function () {

--- a/test/DeIDRegistry.test.js
+++ b/test/DeIDRegistry.test.js
@@ -40,7 +40,7 @@ describe("DeIDRegistry", async function () {
     // identity manager
 
     TXValidator = await ethers.getContractFactory("TXValidator");
-    txValidator = await TXValidator.deploy(validator.address);
+    txValidator = await TXValidator.deploy();
     await txValidator.deployed();
 
     DeIDManager = await ethers.getContractFactory("DeIDManager");

--- a/test/TXValidator.test.js
+++ b/test/TXValidator.test.js
@@ -23,8 +23,9 @@ describe("TXValidator", async function () {
 
   async function initNetworkAndDeploy() {
     TXValidator = await ethers.getContractFactory("TXValidator");
-    txValidator = await TXValidator.deploy(defaultValidator.address);
+    txValidator = await TXValidator.deploy();
     await txValidator.addValidator(1, twitterValidatorName, twitterValidator.address);
+    await txValidator.addValidator(1, instagramValidatorName, instagramValidator.address);
     await txValidator.deployed();
   }
 


### PR DESCRIPTION
I added a default validator to simplify the initial setup, but that is defying the reason for having specific validators for any type of identity. The idea is that is the Federal Government is a validator for American passports, only it can do that. A default validator that is allowed all the time breaks that. So, I removed it.