### PR TITLE
Remove constructor params

### DIFF
--- a/config/deployed.json
+++ b/config/deployed.json
@@ -4,7 +4,10 @@
       "address": "0xC408861DD54174917506F347Cc6FD2c888322D7E",
       "when": "2021-07-04T21:36:14.037Z"
     },
-    "previousVersions": [
-    ]
+    "1337": {
+      "address": "0x67d269191c92Caf3cD7723F116c85e6E9bf55933",
+      "when": "2021-07-05T17:42:03.551Z"
+    },
+    "previousVersions": []
   }
 }

--- a/contracts/DeIDClaimer.sol
+++ b/contracts/DeIDClaimer.sol
@@ -23,14 +23,6 @@ contract DeIDClaimer is StoreCaller, IDeIDClaimer {
     mapping(uint => mapping(address => uint)) private _claimByAddress;
 
 
-    constructor(
-        address store_
-    )
-    StoreCaller(store_)
-    {
-    }
-
-
     function updateProbationTimes(
         uint probationTime_,
         uint afterProbationTime_

--- a/contracts/DeIDManager.sol
+++ b/contracts/DeIDManager.sol
@@ -64,14 +64,15 @@ contract DeIDManager is ClaimerCaller, StoreCaller, IDeIDManager {
         _;
     }
 
-    constructor(
+    function configure(
         address store_,
         address claimer_,
         address validator_
-    )
-    StoreCaller(store_)
-    ClaimerCaller(claimer_)
+    ) external
     {
+        require(hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "Not authorized");
+        setStore(store_);
+        setClaimer(claimer_);
         validator = ITXValidatorMinimal(validator_);
     }
 

--- a/contracts/DeIDStore.sol
+++ b/contracts/DeIDStore.sol
@@ -54,18 +54,16 @@ contract DeIDStore is Application, IDeIDStore {
         _;
     }
 
-    constructor(
+    function setChain (
         uint chainProgressiveId_
-    )
+    ) external override
     {
+        require(hasRole(DEFAULT_ADMIN_ROLE, msg.sender), "Not authorized");
         require(
             chainProgressiveId_ < maxNumberOfChains,
             "chainProgressiveId_ must be < 100"
         );
         chainProgressiveId = chainProgressiveId_;
-        addApp(0x7477697474657200000000000000000000000000000000000000000000000000);
-        addApp(0x7265646469740000000000000000000000000000000000000000000000000000);
-        addApp(0x696e7374616772616d0000000000000000000000000000000000000000000000);
     }
 
     function setExtraKey(

--- a/contracts/interfaces/IDeIDStore.sol
+++ b/contracts/interfaces/IDeIDStore.sol
@@ -16,6 +16,8 @@ interface IDeIDStore {
 
     event UniqueDataChanged(uint indexed _id, bytes32 indexed key, bytes32 value);
 
+    function setChain (uint chainProgressiveId_) external;
+
     function setExtraKey(bytes32 key_, bool unique_, bool immutable_) external;
 
     function getExtras(address address_, bytes32 key_) external view returns (bytes memory value_);

--- a/shell/verify.sh
+++ b/shell/verify.sh
@@ -2,7 +2,7 @@
 # must be run from the root
 
 npx hardhat verify --show-stack-traces --network $1 $2
-npx hardhat verify --show-stack-traces --network $1 --constructor-args tmp/arguments/$1/DeIDStore.js $3
-npx hardhat verify --show-stack-traces --network $1 --constructor-args tmp/arguments/$1/DeIDManager.js $4
-npx hardhat verify --show-stack-traces --network $1 --constructor-args tmp/arguments/$1/DeIDClaimer.js $5
+npx hardhat verify --show-stack-traces --network $1 $3
+npx hardhat verify --show-stack-traces --network $1 $4
+npx hardhat verify --show-stack-traces --network $1 $5
 npx hardhat verify --show-stack-traces --network $1 $6

--- a/test/DeIDClaimer.test.js
+++ b/test/DeIDClaimer.test.js
@@ -40,11 +40,16 @@ describe("DeIDClaimer", async function () {
 
   async function initNetworkAndDeploy() {
     DeIDStore = await ethers.getContractFactory("DeIDStore");
-    store = await DeIDStore.deploy(0);
-    await store.deployed();
+    store = await DeIDStore.deploy()
+    await store.deployed()
+    await store.setChain(0)
+    await store.addApp(utils.stringToBytes32('twitter'))
+    await store.addApp(utils.stringToBytes32('reddit'))
+    await store.addApp(utils.stringToBytes32('instagram'))
     DeIDClaimer = await ethers.getContractFactory("DeIDClaimer");
-    claimer = await DeIDClaimer.deploy(store.address);
+    claimer = await DeIDClaimer.deploy();
     await claimer.deployed();
+    await claimer.setStore(store.address)
     const MANAGER_ROLE = await store.MANAGER_ROLE()
     await store.grantRole(MANAGER_ROLE, manager.address)
     await claimer.grantRole(MANAGER_ROLE, manager.address)

--- a/test/DeIDManager.test.js
+++ b/test/DeIDManager.test.js
@@ -46,11 +46,16 @@ describe("DeIDManager", async function () {
 
   async function initNetworkAndDeploy() {
     DeIDStore = await ethers.getContractFactory("DeIDStore");
-    store = await DeIDStore.deploy(0);
-    await store.deployed();
+    store = await DeIDStore.deploy()
+    await store.deployed()
+    await store.setChain(0)
+    await store.addApp(utils.stringToBytes32('twitter'))
+    await store.addApp(utils.stringToBytes32('reddit'))
+    await store.addApp(utils.stringToBytes32('instagram'))
     DeIDClaimer = await ethers.getContractFactory("DeIDClaimer");
-    claimer = await DeIDClaimer.deploy(store.address);
+    claimer = await DeIDClaimer.deploy();
     await claimer.deployed();
+    await claimer.setStore(store.address)
     TXValidator = await ethers.getContractFactory("TXValidator");
     txValidator = await TXValidator.deploy();
     await txValidator.deployed();
@@ -58,8 +63,9 @@ describe("DeIDManager", async function () {
     await txValidator.addValidator(2, utils.stringToBytes32('tweedentityV2'), validator.address)
     await txValidator.addValidator(3, utils.stringToBytes32('tweedentityV2'), validator.address)
     DeIDManager = await ethers.getContractFactory("DeIDManager");
-    identity = await DeIDManager.deploy(store.address, claimer.address, txValidator.address);
+    identity = await DeIDManager.deploy();
     await identity.deployed();
+    await identity.configure(store.address, claimer.address, txValidator.address)
     const MANAGER_ROLE = await store.MANAGER_ROLE()
     await store.grantRole(MANAGER_ROLE, identity.address)
     await store.grantRole(MANAGER_ROLE, claimer.address)

--- a/test/DeIDRegistry.test.js
+++ b/test/DeIDRegistry.test.js
@@ -31,11 +31,11 @@ describe("DeIDRegistry", async function () {
   async function initNetworkAndDeploy() {
     // store
     DeIDStore = await ethers.getContractFactory("DeIDStore");
-    store = await DeIDStore.deploy(0);
+    store = await DeIDStore.deploy();
     await store.deployed();
     //claimer
     DeIDClaimer = await ethers.getContractFactory("DeIDClaimer");
-    claimer = await DeIDClaimer.deploy(store.address);
+    claimer = await DeIDClaimer.deploy();
     await claimer.deployed();
     // identity manager
 
@@ -44,13 +44,8 @@ describe("DeIDRegistry", async function () {
     await txValidator.deployed();
 
     DeIDManager = await ethers.getContractFactory("DeIDManager");
-    identity = await DeIDManager.deploy(store.address, claimer.address, txValidator.address);
+    identity = await DeIDManager.deploy();
     await identity.deployed();
-
-    const MANAGER_ROLE = await store.MANAGER_ROLE()
-    await store.grantRole(MANAGER_ROLE, identity.address)
-    await store.grantRole(MANAGER_ROLE, claimer.address)
-    await claimer.grantRole(MANAGER_ROLE, identity.address)
 
     Registry = await ethers.getContractFactory("DeIDRegistry");
     registry = await Registry.deploy();

--- a/test/DeIDStore.test.js
+++ b/test/DeIDStore.test.js
@@ -39,8 +39,12 @@ describe("DeIDStore", async function () {
 
   async function initNetworkAndDeploy() {
     DeIDStore = await ethers.getContractFactory("DeIDStore")
-    store = await DeIDStore.deploy(0)
+    store = await DeIDStore.deploy()
     await store.deployed()
+    await store.setChain(0)
+    await store.addApp(utils.stringToBytes32('twitter'))
+    await store.addApp(utils.stringToBytes32('reddit'))
+    await store.addApp(utils.stringToBytes32('instagram'))
     const MANAGER_ROLE = await store.MANAGER_ROLE()
     await store.grantRole(MANAGER_ROLE, manager.address)
   }


### PR DESCRIPTION
To simplify source contract verification (that sometimes fails in Etherscan) I removed the constructor params. It costs a bit more gas.